### PR TITLE
fix install

### DIFF
--- a/install.py
+++ b/install.py
@@ -43,15 +43,14 @@ if platform == 'sd-webui':
         else:
             launch.run_pip('install onnxruntime==1.17.3', 'onnxruntime')
 
-    if not launch.is_installed('chara-searcher requirements'):
-        transformers_lines = [item for item in pip_list_lines if item.startswith('transformers')]
-        transformers_version = None
-        if transformers_lines and len(transformers_lines) > 0:
-            transformers_version = transformers_lines[0].split()[-1]
-        if transformers_version is None:
-            launch.run_pip('install -r requirements.txt', 'chara-searcher requirements')
-        else:
-            launch.run_pip('install transformers==' + transformers_version + ' -r requirements.txt', 'chara-searcher requirements')
+    transformers_lines = [item for item in pip_list_lines if item.startswith('transformers')]
+    transformers_version = None
+    if transformers_lines and len(transformers_lines) > 0:
+        transformers_version = transformers_lines[0].split()[-1]
+    if transformers_version is None:
+        launch.run_pip('install -r requirements.txt', 'chara-searcher requirements')
+    else:
+        launch.run_pip('install transformers==' + transformers_version + ' -r requirements.txt', 'chara-searcher requirements')
 
 elif platform == 'standalone':
     os.chdir(os.path.dirname(__file__))

--- a/install.py
+++ b/install.py
@@ -89,6 +89,8 @@ elif platform == 'standalone':
 
     subprocess.run([sys.executable, '-m', 'pip', 'install', 'transformers>=4.34.0'])
 
+    subprocess.run([sys.executable, '-m', 'pip', 'install', 'gradio==3.41.2'])
+
     subprocess.run([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'])
 
 os.chdir(os.path.join(os.path.dirname(__file__), 'CartoonSegmentation'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 tqdm
 sentence-transformers
-gradio==3.41.2
 av
 
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ imageio
 imgaug
 git+https://github.com/cocodataset/panopticapi.git
 pytorch-lightning
-albumentations==1.1.0
+albumentations<1.4.4
 huggingface_hub
 omegaconf
 diffusers


### PR DESCRIPTION
move gradio==3.41.2 out of requirements.txt
prevent extension from breaking web UI when gradio version is different

albumentations ==1.1.0 to <1.4.4
reduce package conflicts with other extensions
- fore more info see https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15564
I did not test this extension extensively but seems to work with albumentations==1.4.3

[remove strange check](https://github.com/NON906/chara-searcher/commit/8ba964a6e7820db99117bdb7fd7fafb456a2e3b4)
as far as I can tell `if not launch.is_installed('chara-searcher requirements'):` dose not have a purpose because it always returns True as `chara-searcher requirements` is not a module and so always return False
